### PR TITLE
Add opt-in preflight checks for release flow

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -30,6 +30,10 @@ class Builder {
     return this.config.testers;
   }
 
+  get preflightConfig() {
+    return this.config.preflightConfig;
+  }
+
   constructor(config: Config, commandExecutor?: CommandExecutor, logger?: Logger) {
     this.config = config;
     this.commandExecutor = commandExecutor || cmd;
@@ -101,6 +105,44 @@ class Builder {
     this.selectAssets(assetNames).forEach((asset: Asset) => {
       this.cleanAsset(asset);
     });
+  }
+
+  preflight() {
+    const preflight = this.preflightConfig;
+
+    if (!preflight.hasChecks()) {
+      this.logger.log('No preflight checks configured, skipping', ['yellow']);
+      return;
+    }
+
+    this.logger.section('Preflight checks...', () => {
+      if (preflight.gitClean) this.checkGitClean();
+      if (preflight.gitInSyncWithBaseBranch) this.checkGitInSyncWithBaseBranch();
+      if (preflight.npmAuth) this.checkNpmAuth();
+    });
+  }
+
+  private checkGitClean() {
+    this.logger.log('Checking git working tree is clean', ['yellow']);
+    this.commandExecutor('test -z "$(git status --porcelain)"');
+    this.logger.log('Working tree is clean', ['green']);
+  }
+
+  private checkGitInSyncWithBaseBranch() {
+    this.logger.log('Checking HEAD is not behind the base branch', ['yellow']);
+    this.commandExecutor(
+      'BASE=$(git rev-parse --abbrev-ref origin/HEAD) && ' +
+      // eslint-disable-next-line no-template-curly-in-string
+      'git fetch --quiet origin "${BASE#origin/}" && ' +
+      'git merge-base --is-ancestor "$BASE" HEAD',
+    );
+    this.logger.log('HEAD is in sync with the base branch', ['green']);
+  }
+
+  private checkNpmAuth() {
+    this.logger.log('Checking npm auth', ['yellow']);
+    this.commandExecutor('yarn npm whoami');
+    this.logger.log('npm auth OK', ['green']);
   }
 
   bump(version: string) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,6 +62,11 @@ class CLI {
       .action(this.ci.bind(this));
 
     program
+      .command('preflight')
+      .description('Run configured pre-release checks')
+      .action(this.preflight.bind(this));
+
+    program
       .command('bump')
       .description('Bump version')
       .argument('<version>', 'Version to bump to')
@@ -112,6 +117,10 @@ class CLI {
     this.build([], { release: true });
   }
 
+  private preflight() {
+    this.builder.preflight();
+  }
+
   private bump(version: string) {
     this.builder.bump(version);
   }
@@ -125,6 +134,7 @@ class CLI {
   }
 
   private release(version: string) {
+    this.preflight();
     this.build([], { release: false });
     this.lint({ fix: false });
     this.test();

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,8 @@ import Asset from './asset';
 import AssetOptions from './types/asset_options';
 import Linter from './linter';
 import LinterOptions from './types/linter_options';
+import Preflight from './preflight';
+import PreflightOptions from './types/preflight_options';
 import Tester from './tester';
 import TesterOptions from './types/tester_options';
 
@@ -11,6 +13,8 @@ class Config {
   linters: Record<string, Linter> = {};
 
   testers: Record<string, Tester> = {};
+
+  preflightConfig: Preflight = new Preflight();
 
   constructor(callback?: (config: Config) => void) {
     if (callback) callback(this);
@@ -32,6 +36,11 @@ class Config {
     const tester = new Tester(name, options);
     this.testers[name] = tester;
     return tester;
+  }
+
+  preflight(options: PreflightOptions): Preflight {
+    this.preflightConfig = new Preflight(options);
+    return this.preflightConfig;
   }
 }
 

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -1,0 +1,21 @@
+import PreflightOptions from './types/preflight_options';
+
+class Preflight {
+  gitClean: boolean;
+
+  gitInSyncWithBaseBranch: boolean;
+
+  npmAuth: boolean;
+
+  constructor(options: PreflightOptions = {}) {
+    this.gitClean = options.gitClean ?? false;
+    this.gitInSyncWithBaseBranch = options.gitInSyncWithBaseBranch ?? false;
+    this.npmAuth = options.npmAuth ?? false;
+  }
+
+  hasChecks(): boolean {
+    return this.gitClean || this.gitInSyncWithBaseBranch || this.npmAuth;
+  }
+}
+
+export default Preflight;

--- a/src/types/preflight_options.ts
+++ b/src/types/preflight_options.ts
@@ -1,0 +1,7 @@
+interface PreflightOptions {
+  gitClean?: boolean;
+  gitInSyncWithBaseBranch?: boolean;
+  npmAuth?: boolean;
+}
+
+export default PreflightOptions;

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -503,6 +503,79 @@ describe('Builder', () => {
     });
   });
 
+  describe('#preflight', () => {
+    it('does nothing when no preflight is configured', () => {
+      const config = new Config();
+      const mockCommandExecutor = new MockCommandExecutor();
+
+      const builder = new Builder(
+        config,
+        mockCommandExecutor.execute.bind(mockCommandExecutor),
+        new NullLogger(),
+      );
+
+      builder.preflight();
+
+      expect(mockCommandExecutor.executedCommands).toEqual([]);
+    });
+
+    it('does nothing when no checks are enabled', () => {
+      const config = new Config();
+      config.preflight({});
+      const mockCommandExecutor = new MockCommandExecutor();
+
+      const builder = new Builder(
+        config,
+        mockCommandExecutor.execute.bind(mockCommandExecutor),
+        new NullLogger(),
+      );
+
+      builder.preflight();
+
+      expect(mockCommandExecutor.executedCommands).toEqual([]);
+    });
+
+    it('runs only the enabled checks', () => {
+      const config = new Config();
+      config.preflight({ gitClean: true, npmAuth: true });
+      const mockCommandExecutor = new MockCommandExecutor();
+
+      const builder = new Builder(
+        config,
+        mockCommandExecutor.execute.bind(mockCommandExecutor),
+        new NullLogger(),
+      );
+
+      builder.preflight();
+
+      expect(mockCommandExecutor.executedCommands).toEqual([
+        'test -z "$(git status --porcelain)"',
+        'yarn npm whoami',
+      ]);
+    });
+
+    it('detects the base branch via origin/HEAD, fetches it and checks ancestry', () => {
+      const config = new Config();
+      config.preflight({ gitInSyncWithBaseBranch: true });
+      const mockCommandExecutor = new MockCommandExecutor();
+
+      const builder = new Builder(
+        config,
+        mockCommandExecutor.execute.bind(mockCommandExecutor),
+        new NullLogger(),
+      );
+
+      builder.preflight();
+
+      expect(mockCommandExecutor.executedCommands).toEqual([
+        'BASE=$(git rev-parse --abbrev-ref origin/HEAD) && ' +
+        // eslint-disable-next-line no-template-curly-in-string
+        'git fetch --quiet origin "${BASE#origin/}" && ' +
+        'git merge-base --is-ancestor "$BASE" HEAD',
+      ]);
+    });
+  });
+
   describe('#bump', () => {
     it('bumps the version in package.json', () => {
       const config = new Config();

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -10,6 +10,7 @@ function buildMockBuilder() {
     bump: jest.fn(),
     publish: jest.fn(),
     gitPush: jest.fn(),
+    preflight: jest.fn(),
     release: jest.fn(),
   };
 }
@@ -212,6 +213,19 @@ describe('CLI', () => {
       cli.run(['', 'unibuild', 'publish']);
 
       expect(mockBuilder.publish).toHaveBeenCalled();
+    });
+  });
+
+  describe('preflight', () => {
+    it('calls builder.preflight', () => {
+      const config = new Config(() => {
+      });
+      const mockBuilder = buildMockBuilder();
+      const cli = new CLI(config, mockBuilder as any);
+
+      cli.run(['', 'unibuild', 'preflight']);
+
+      expect(mockBuilder.preflight).toHaveBeenCalled();
     });
   });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -48,4 +48,36 @@ describe('Config', () => {
       expect(config.testers.jest).toBe(tester);
     });
   });
+
+  describe('#preflight', () => {
+    it('creates and stores a Preflight instance', () => {
+      const config = new Config();
+      const preflight = config.preflight({ gitClean: true });
+
+      expect(preflight).toBeDefined();
+      expect(preflight.gitClean).toBe(true);
+      expect(config.preflightConfig).toBe(preflight);
+    });
+
+    it('defaults all checks to false', () => {
+      const config = new Config();
+      const preflight = config.preflight({});
+
+      expect(preflight.gitClean).toBe(false);
+      expect(preflight.gitInSyncWithBaseBranch).toBe(false);
+      expect(preflight.npmAuth).toBe(false);
+      expect(preflight.hasChecks()).toBe(false);
+    });
+  });
+
+  describe('#preflightConfig', () => {
+    it('is a Preflight with all checks disabled when preflight() is never called', () => {
+      const config = new Config();
+
+      expect(config.preflightConfig.hasChecks()).toBe(false);
+      expect(config.preflightConfig.gitClean).toBe(false);
+      expect(config.preflightConfig.gitInSyncWithBaseBranch).toBe(false);
+      expect(config.preflightConfig.npmAuth).toBe(false);
+    });
+  });
 });

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -1,0 +1,57 @@
+import Preflight from '../src/preflight';
+
+describe('Preflight', () => {
+  describe('with no options', () => {
+    it('defaults all checks to false', () => {
+      const preflight = new Preflight();
+
+      expect(preflight.gitClean).toBe(false);
+      expect(preflight.gitInSyncWithBaseBranch).toBe(false);
+      expect(preflight.npmAuth).toBe(false);
+    });
+
+    it('reports no checks', () => {
+      const preflight = new Preflight();
+
+      expect(preflight.hasChecks()).toBe(false);
+    });
+  });
+
+  describe('with an empty options object', () => {
+    it('defaults all checks to false', () => {
+      const preflight = new Preflight({});
+
+      expect(preflight.gitClean).toBe(false);
+      expect(preflight.gitInSyncWithBaseBranch).toBe(false);
+      expect(preflight.npmAuth).toBe(false);
+      expect(preflight.hasChecks()).toBe(false);
+    });
+  });
+
+  describe('with gitClean enabled', () => {
+    it('reports it has checks', () => {
+      const preflight = new Preflight({ gitClean: true });
+
+      expect(preflight.gitClean).toBe(true);
+      expect(preflight.hasChecks()).toBe(true);
+    });
+  });
+
+  describe('with gitInSyncWithBaseBranch enabled', () => {
+    it('reports it has checks', () => {
+      const preflight = new Preflight({ gitInSyncWithBaseBranch: true });
+
+      expect(preflight.gitInSyncWithBaseBranch).toBe(true);
+      expect(preflight.hasChecks()).toBe(true);
+    });
+  });
+
+  describe('with npmAuth enabled', () => {
+    it('reports it has checks', () => {
+      const preflight = new Preflight({ npmAuth: true });
+
+      expect(preflight.npmAuth).toBe(true);
+      expect(preflight.hasChecks()).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds a `preflight` step that runs at the very start of `unibuild release <version>`, with three built-in checks. All default to off — opt in via `u.preflight({...})` in the unibuild config.

- `gitClean` — fails if `git status --porcelain` is non-empty
- `gitInSyncWithBaseBranch: 'origin/master'` — fetches the remote (when the ref contains `<remote>/<branch>`) then asserts the ref is an ancestor of `HEAD`
- `npmAuth` — runs `yarn npm whoami`

Also exposes a standalone `unibuild preflight` command for running the checks outside a release.

## Why
Currently the release flow can fail on `git push` (branch protection, out-of-sync base, no push rights) or `yarn npm publish` (auth expired) *after* `npm version` has already created a bump commit and tag, leaving the repo in a half-released state. Preflight moves those failures to the top of the flow.

## Design
- `Config.preflightConfig` is always a `Preflight` instance (default: all checks false), so never calling `.preflight()` and calling `.preflight({})` are indistinguishable — both skip cleanly.
- Checks each expressed as a command that must exit 0; failures propagate via the existing `commandExecutor` throw path.

## Test plan
- [x] `Preflight` unit tests: defaults, `hasChecks()`, per-check flag
- [x] `Config`: default `preflightConfig`, `.preflight()` register + defaults-to-false
- [x] `Builder#preflight`: skip when nothing configured / empty options, runs only enabled checks, remote-prefix fetch behavior
- [x] `CLI preflight` command
- [x] Full suite: 95 tests pass, lint clean