### PR TITLE
Use unibuild to build unibuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,11 @@
     "ts-node": "^10.9.2"
   },
   "scripts": {
-    "ci": "yarn lint && yarn test",
-    "lint": "node_modules/.bin/eslint",
-    "lint:fix": "node_modules/.bin/eslint --fix",
-    "test": "jest"
+    "ci": "yarn unibuild ci",
+    "lint": "yarn unibuild lint",
+    "lint:fix": "yarn unibuild lint --fix",
+    "test": "yarn unibuild test",
+    "preflight": "yarn unibuild preflight",
+    "release": "yarn unibuild release"
   }
 }

--- a/unibuild.ts
+++ b/unibuild.ts
@@ -1,0 +1,20 @@
+import unibuild from './src';
+
+export default unibuild((u) => {
+  u.lint('eslint', {
+    command: 'node_modules/.bin/eslint',
+    autofixCommand: 'node_modules/.bin/eslint --fix',
+    requires: [],
+  });
+
+  u.test('jest', {
+    command: 'jest',
+    requires: [],
+  });
+
+  u.preflight({
+    gitClean: true,
+    gitInSyncWithBaseBranch: true,
+    npmAuth: true,
+  });
+});


### PR DESCRIPTION
## Summary
- Add `unibuild.ts` config that registers eslint, jest and enables all three preflight checks
- Route `lint`, `test`, `preflight`, `release` and `ci` scripts through `yarn unibuild`

This dogfoods the release orchestration: releasing unibuild now goes through the same preflight → bump → push → publish flow as consumer projects.